### PR TITLE
remove button margin to fix chat text send alignment

### DIFF
--- a/client/src/pages/style.css
+++ b/client/src/pages/style.css
@@ -1,8 +1,4 @@
 @import url('https://fonts.googleapis.com/css2?family=Charmonman:wght@700&display=swap');
-.btn {
-  margin-top: 10px;
-
-}
 
 body {
   background: url(../assets/background4.png);


### PR DESCRIPTION
had to take btn styling from pages/style.css to fix dashboard. Adding the margin was causing it to not line up for the chat page.